### PR TITLE
Add constant fields to a logger instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2022-07-18 0.5.0
+
+### Added functionality
+
+- Add constant fields to a logger instance
+
 ## 2022-07-11 0.4.0
 
 ### Added functionality

--- a/README.md
+++ b/README.md
@@ -94,3 +94,16 @@ const logger = new Logger({
   },
 });
 ```
+
+## Add constant fields to each record for the logger
+
+```js
+import { Logger } from "consigliere";
+
+const logger = new Logger({
+  fields: {
+    application: "my-app",
+    version: "0.0.1",
+  },
+});
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consigliere",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "🍝 A simple to use JSON logger",
   "keywords": [
     "logger",

--- a/src/lib/log/index.ts
+++ b/src/lib/log/index.ts
@@ -30,6 +30,7 @@ export function log(subject: any, enrichment = {}): any {
   const parser = getParser(this);
 
   const output = parser.call(context, {
+    ...this.fields,
     ...enrichment,
     ...record,
     level: this.level,

--- a/src/lib/logger/index.ts
+++ b/src/lib/logger/index.ts
@@ -12,17 +12,20 @@ export class Logger {
   #minimal: number = 0;
   #device: Function = console.log;
   #parser: false | Function = NORMALISE;
+  #fields: object;
   [key: string]: any;
   constructor({
     levels = LEVELS,
     level = levels.at(0),
     device = console.log,
     parser = NORMALISE,
+    fields = {},
   } = {}) {
     this.#setDevice(device);
     this.#setLevels(levels);
     this.#setLevel(level);
     this.#setParser(parser);
+    this.#setFields(fields);
 
     return new Proxy(this, {
       get(logger: Logger, prop: string | symbol) {
@@ -48,7 +51,12 @@ export class Logger {
             }
             return levels.indexOf(prop) < logger.#minimal
               ? () => Promise.resolve(undefined)
-              : log.bind({ level: prop, device, parser: logger.#parser });
+              : log.bind({
+                  level: prop,
+                  device,
+                  parser: logger.#parser,
+                  fields: logger.#fields,
+                });
         }
       },
       set(logger: Logger, prop: string | symbol, value): boolean {
@@ -122,5 +130,14 @@ export class Logger {
       );
     }
     this.#device = device;
+  }
+
+  #setFields(fields: object): void {
+    if (fields.toString() !== "[object Object]") {
+      throw new TypeError(
+        `fields must be an object, instead got ${typeof fields} (${fields})`
+      );
+    }
+    this.#fields = fields;
   }
 }

--- a/src/lib/logger/test.ts
+++ b/src/lib/logger/test.ts
@@ -52,6 +52,30 @@ describe("lib/logger", () => {
     logger.info("Hello");
     expect(console.log).toHaveBeenCalledTimes(1);
   });
+  it("can set constant fields to a logger", () => {
+    const logger = new Logger({ level: "warn", fields: { version: "1.0.0" } });
+    logger.warn({ key: "Value" });
+    const [[record]] = (console.log as jest.Mock).mock.calls;
+    expect(JSON.parse(record)).toEqual({
+      key: "Value",
+      version: "1.0.0",
+      level: "warn",
+    });
+  });
+  it("log object takes presedence to constant fields", () => {
+    const logger = new Logger({
+      level: "warn",
+      fields: { version: "1.0.0", app: "my-app" },
+    });
+    logger.warn({ key: "Value", version: "2.0.0" });
+    const [[record]] = (console.log as jest.Mock).mock.calls;
+    expect(JSON.parse(record)).toEqual({
+      key: "Value",
+      version: "2.0.0",
+      app: "my-app",
+      level: "warn",
+    });
+  });
   it("Logger has proper getters", () => {
     const logger = new Logger({ level: "warn" });
     expect(logger.toString()).toBe("Logger(warn)");


### PR DESCRIPTION
## Add constant fields to each record for the logger

```js
import { Logger } from "consigliere";

const logger = new Logger({
  fields: {
    application: "my-app",
    version: "0.0.1",
  },
});
```